### PR TITLE
Add (commented) line to Norne script to allow run with hysteresis

### DIFF
--- a/autodiff/ad-blackoil/examples/fieldModelNorneExample.m
+++ b/autodiff/ad-blackoil/examples/fieldModelNorneExample.m
@@ -27,6 +27,8 @@ rock = initEclipseRock(deck);
 rock = compressRock(rock, G_sim.cells.indexMap);
 
 fluid = initDeckADIFluid(deck, 'useMex', useMex);
+% fluid.ehystr{2} = 2; % uncomment this line to run with hysteresis
+
 % Setup model, but skip setting up the operators since we do not have a
 % proper grid
 model = GenericBlackOilModel(G_sim, [], fluid, 'disgas', true, 'vapoil', true, 'inputdata', deck);


### PR DESCRIPTION
The example in `fieldModelNorneExample` does not actually run with hysteresis, since this requires having set the hysteresis model to Killough (only one supported), which is not done by default.  

Adding the line `fluid.ehystr{2} = 2` addresses the issue.  It is now added in the script in commented-out form, so that users may activate hysteresis if desired.