### PR TITLE
Pick up Octave-Only Features Relative to 'Core'

### DIFF
--- a/startup.m
+++ b/startup.m
@@ -119,7 +119,7 @@ end
 
 function run_platform_specific()
    if mrstPlatform('octave')
-      do_run_local(fullfile(rootdir(), 'utils', ...
+      do_run_local(fullfile(rootdir(), 'core', 'utils', ...
                             'octave_only', 'startup_octave.m'));
    end
 end


### PR DESCRIPTION
In particular, this restores the [`struct_levels_to_print`](https://github.com/SINTEF-AppliedCompSci/MRST/blob/cc8b968098f19a1a8d889e99ef3f894e5170eb3b/core/utils/octave_only/startup_octave.m#L1) setting.